### PR TITLE
Remove extra space in message to maintain consistency

### DIFF
--- a/BNLSProtocol/BNLSServer.java
+++ b/BNLSProtocol/BNLSServer.java
@@ -27,7 +27,7 @@ public class BNLSServer extends Thread{
 	private boolean listening=false;
 
 	public BNLSServer() {
-		Out.println("JBLS"," Server thread created.");
+		Out.println("JBLS","Server thread created.");
 	}
 
 	//Starts the Server Listening process (infinatly blocking loop)


### PR DESCRIPTION
To maintain message consistency when starting the JBLS server, I removed an extra space from a message that must have got in by mistake.