### PR TITLE
Warcraft 3 Demo Support

### DIFF
--- a/BNLSProtocol/BNLSParse.java
+++ b/BNLSProtocol/BNLSParse.java
@@ -87,6 +87,7 @@ public class BNLSParse{
    * private static final byte PRODUCT_DIABLO             = 0x09; //Fully Supported
    * private static final byte PRODUCT_DIABLOSHAREWARE    = 0x0A; //Fully Supported
    * private static final byte PRODUCT_STARCRAFTSHAREWARE = 0x0B; //Fully Supported
+   * private static final byte PRODUCT_WAR3DEMO           = 0x0C; //Fully Supported
    */
   
   /*Flag definitions for BNLS_CDKEY_EX*/

--- a/HTTP/HTTPParse.java
+++ b/HTTP/HTTPParse.java
@@ -76,6 +76,7 @@ public class HTTPParse extends Thread{
     "      <tr><td class=li>JSTR Checks</td><td class=li><jstr></td><td class=li><jstrvb></td></tr>" + CRLF +
     "      <tr><td class=li>W3XP Checks</td><td class=li><war3></td><td class=li><war3vb></td></tr>" + CRLF +
     "      <tr><td class=li>DRTL Checks</td><td class=li><drtl></td><td class=li><drtlvb></td></tr>" + CRLF +
+    "      <tr><td class=li>W3DM Checks</td><td class=li><w3dm></td><td class=li><w3dmvb></td></tr>" + CRLF +
     "    </table>" + CRLF +
     "    <table width=550 align=center cellpadding=3 cellspacing=0 border=0>" + CRLF +
     "      <tr><td align=left colspan=2><span class=subheader>Additional Information</span></td></tr>" + CRLF +
@@ -143,6 +144,7 @@ public class HTTPParse extends Thread{
        	  page = page.replaceAll("<drtl>", String.valueOf(HashMain.CRevChecks[8]));
        	  page = page.replaceAll("<dshr>", String.valueOf(HashMain.CRevChecks[9]));
        	  page = page.replaceAll("<sshr>", String.valueOf(HashMain.CRevChecks[10]));
+       	  page = page.replaceAll("<w3dm>", String.valueOf(HashMain.CRevChecks[11]));
        	  page = page.replaceAll("<starvb>", hex(Constants.IX86verbytes[Constants.PRODUCT_STARCRAFT - 1]));
        	  page = page.replaceAll("<w2bnvb>", hex(Constants.IX86verbytes[Constants.PRODUCT_WAR2BNE - 1]));
        	  page = page.replaceAll("<d2dvvb>", hex(Constants.IX86verbytes[Constants.PRODUCT_DIABLO2 - 1]));
@@ -152,6 +154,7 @@ public class HTTPParse extends Thread{
        	  page = page.replaceAll("<drtlvb>", hex(Constants.IX86verbytes[Constants.PRODUCT_DIABLO - 1]));
        	  page = page.replaceAll("<dshrvb>", hex(Constants.IX86verbytes[Constants.PRODUCT_DIABLOSHAREWARE - 1]));
        	  page = page.replaceAll("<sshrvb>", hex(Constants.IX86verbytes[Constants.PRODUCT_STARCRAFTSHAREWARE - 1]));
+       	  page = page.replaceAll("<w3dmvb>", hex(Constants.IX86verbytes[Constants.PRODUCT_WAR3DEMO - 1]));
        	  page = page.replaceAll("<auth>", String.valueOf(Constants.requireAuthorization));
        	  page = page.replaceAll("<build>", Constants.build);
        	  page = page.replaceAll("<news>", Constants.strNews[0]+"<br \\>"+Constants.strNews[1]+"<br \\>"+Constants.strNews[2]+"<br \\>"+Constants.strNews[3]+"<br \\>"+Constants.strNews[4]);
@@ -238,7 +241,9 @@ public class HTTPParse extends Thread{
         else if(file.equalsIgnoreCase("/DSHR.zip"))
           sendHashFile("DSHR", Constants.DSHRfiles);
         else if(file.equalsIgnoreCase("/SSHR.zip"))
-          sendHashFile("SSHR", Constants.SSHRfiles);*/
+          sendHashFile("SSHR", Constants.SSHRfiles);
+        else if(file.equalsIgnoreCase("/W3DM.zip"))
+          sendHashFile("W3DM", Constants.W3DMfiles);*/
         else{
           send404(file);
         }

--- a/Hashing/CheckRevisionV1.java
+++ b/Hashing/CheckRevisionV1.java
@@ -336,7 +336,9 @@ public class CheckRevisionV1
       int ver = 0;
       try{
         ver = PE.getVersion(files[0], false);
-        if(prod == Constants.PRODUCT_WARCRAFT3 || prod == Constants.PRODUCT_THEFROZENTHRONE){
+        if(prod == Constants.PRODUCT_WARCRAFT3 ||
+           prod == Constants.PRODUCT_THEFROZENTHRONE ||
+           prod == Constants.PRODUCT_WAR3DEMO){
           ver = (ver & 0xFF000000) >>> 24 |
                 (ver & 0x00FF0000) >> 8 |
                 (ver & 0x0000FF00) << 8 |

--- a/Hashing/HashMain.java
+++ b/Hashing/HashMain.java
@@ -19,7 +19,7 @@ import util.*;
 public class HashMain {
 
   //Only compilied once(as needed), then stored
-  public  static int    CRevChecks[] = new int[0x0B];
+  public  static int    CRevChecks[] = new int[0x0C];
 
   public static int WAR3KeysHashed=0;
   public static int STARKeysHashed=0;

--- a/Hashing/HashMain.java
+++ b/Hashing/HashMain.java
@@ -19,7 +19,7 @@ import util.*;
 public class HashMain {
 
   //Only compilied once(as needed), then stored
-  public  static int    CRevChecks[] = new int[0x0C];
+  public static int CRevChecks[] = new int[0x0C];
 
   public static int WAR3KeysHashed=0;
   public static int STARKeysHashed=0;

--- a/util/Constants.java
+++ b/util/Constants.java
@@ -1,7 +1,7 @@
 package util;
 
 public final class Constants{
-    
+
     public static final byte PLATFORM_INTEL   = 0x01;
     public static final byte PLATFORM_POWERPC = 0x02;
     public static final byte PLATFORM_MACOSX  = 0x03;
@@ -17,27 +17,29 @@ public final class Constants{
     public static final byte PRODUCT_DIABLO            = 0x09;
     public static final byte PRODUCT_DIABLOSHAREWARE   = 0x0A;
     public static final byte PRODUCT_STARCRAFTSHAREWARE= 0x0B;
-    public static String[] prods = {"STAR", "SEXP", "W2BN", "D2DV", "D2XP", "JSTR", "WAR3", "W3XP", "DRTL", "DSHR", "SSHR"};
+    public static final byte PRODUCT_WAR3DEMO          = 0x0C;
+    public static String[] prods = {"STAR", "SEXP", "W2BN", "D2DV", "D2XP", "JSTR", "WAR3", "W3XP", "DRTL", "DSHR", "SSHR", "W3DM"};
     public static String[][] IX86files = {
-        {"IX86/STAR/", "StarCraft.exe",       "Storm.dll",    "NULL",   	  "STAR.bin"},
-        {"IX86/STAR/", "StarCraft.exe",       "Storm.dll",    "NULL",   	  "STAR.bin"},
-        {"IX86/W2BN/", "Warcraft II BNE.exe", "Storm.dll",    "Battle.snp",   "W2BN.bin"},
-        {"IX86/D2DV/", "Game.exe",            "NULL", 		  "NULL", 		  "D2DV.bin"},
-        {"IX86/D2XP/", "Game.exe",            "NULL", 		  "NULL", 		  "D2XP.bin"},
-        {"IX86/JSTR/", "StarcraftJ.exe",      "Storm.dll",    "Battle.snp",   "JSTR.bin"},
-        {"IX86/WAR3/", "Warcraft III.exe",    "NULL",    	  "NULL",     	  "WAR3.bin"},
-        {"IX86/WAR3/", "Warcraft III.exe",    "NULL",    	  "NULL",     	  "WAR3.bin"},
-        {"IX86/DRTL/", "Diablo.exe",          "Storm.dll",    "Battle.snp",   "DRTL.bin"},
-        {"IX86/DSHR/", "Diablo_s.exe",        "Storm.dll",    "Battle.snp",   "DSHR.bin"},
-        {"IX86/SSHR/", "Starcraft.exe",       "Storm.dll",    "Battle.snp",   "SSHR.bin"}
+        {"IX86/STAR/", "StarCraft.exe",       "Storm.dll", "NULL",       "STAR.bin"},
+        {"IX86/STAR/", "StarCraft.exe",       "Storm.dll", "NULL",       "STAR.bin"},
+        {"IX86/W2BN/", "Warcraft II BNE.exe", "Storm.dll", "Battle.snp", "W2BN.bin"},
+        {"IX86/D2DV/", "Game.exe",            "NULL",      "NULL",       "D2DV.bin"},
+        {"IX86/D2XP/", "Game.exe",            "NULL",      "NULL",       "D2XP.bin"},
+        {"IX86/JSTR/", "StarcraftJ.exe",      "Storm.dll", "Battle.snp", "JSTR.bin"},
+        {"IX86/WAR3/", "Warcraft III.exe",    "NULL",      "NULL",       "WAR3.bin"},
+        {"IX86/WAR3/", "Warcraft III.exe",    "NULL",      "NULL",       "WAR3.bin"},
+        {"IX86/DRTL/", "Diablo.exe",          "Storm.dll", "Battle.snp", "DRTL.bin"},
+        {"IX86/DSHR/", "Diablo_s.exe",        "Storm.dll", "Battle.snp", "DSHR.bin"},
+        {"IX86/SSHR/", "Starcraft.exe",       "Storm.dll", "Battle.snp", "SSHR.bin"},
+        {"IX86/W3DM/", "War3Demo.exe",        "Storm.dll", "Game.dll",   "W3DM.bin"}
     };
-    public static int[] IX86verbytes = {0xD3, 0xD3, 0x4f, 0x0e, 0x0e, 0xa9, 0x1E, 0x1E, 0x2a, 0x2a, 0xa5};
+    public static int[] IX86verbytes = {0xD3, 0xD3, 0x4f, 0x0e, 0x0e, 0xa9, 0x1E, 0x1E, 0x2a, 0x2a, 0xa5, 0x01};
     public static String[] IX86versions = {"", "", "2.0.2.1", "1.14.3.71", "1.14.3.71", "", "", "", "2001, 5, 18, 1", "", ""};
     public static String[] IX86certs = {"", "", "", "", "", "", "", "", "", "", ""};
-    
+
     public static String ArchivePath = "DLLs/";
     public static String LogFilePath = "./Logs/";
-    
+
     public static String build="Build V3.1 Bug Fixes, SQL Stats tracking. (10-14-07)";
     //public static String build="Build V3.0 BotNet Admin, Lockdown, Legacy Clients.(07-07-07)";
     //public static String build="Build V2.9 Remote admin, extended admin commands w/ JSTR support.(01/18/06)";
@@ -60,7 +62,7 @@ public final class Constants{
     public static String   BotNetUsername = "";
     public static String   BotNetPassword = "";
     public static String   BotNetServer   = "www.valhallalegends.com";
-	
+
     public static boolean LogStats         = false;
     public static String  StatsUsername    = "";
     public static String  StatsPassword    = "";
@@ -72,12 +74,12 @@ public final class Constants{
     public static boolean StatsLogBotIDs   = true;
     public static boolean StatsLogConns    = true;
     public static boolean StatsCheckSchema = true;
-    
+
     public static String DownloadPath = "./";
-    
+
     public static boolean RunHTTP = true;
     public static int     HTTPPort = 81;
-    
+
     public static int lngServerVer=0x01;
     public static int numOfNews=0;
     public static String[] strNews={"", "", "", "", ""};


### PR DESCRIPTION
* Adds Warcraft III Demo support to JBLS (BNLS product code `0x0C`)
* It will be very difficult to test this due to Blizzard killing off the `demo.war3.battle.net` server.
* When #5 was opened, sending W3DM as a product code in [C>S 0x50 SID_AUTH_INFO](https://bnetdocs.org/packet/279/sid-auth-info) to `uswest.battle.net` caused the connection to be disconnected without ban.
* Fixed merge conflicts from #5.